### PR TITLE
tensorflow 2.0 not having attribute python

### DIFF
--- a/keras_attention_layer.py
+++ b/keras_attention_layer.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from tensorflow.python import keras
 from tensorflow.python.keras.layers import Layer
-import tensorflow.python.keras.backend as K
+from tensorflow.python.keras import backend as K
 from typing import Optional
 
 


### PR DESCRIPTION
in tensorflow 2.0 replacing "import tensorflow.python.keras.backend" as K with "from tensorflow.python.keras import backend as K"
solves the error tensorflow does not have attribute 'python'.