### PR TITLE
Simple change in the _TFEvaluateModelInputTensorsFormer class converter

### DIFF
--- a/tensorflow_model.py
+++ b/tensorflow_model.py
@@ -529,10 +529,10 @@ class _TFTrainModelInputTensorsFormer(ModelInputTensorsFormer):
 
 class _TFEvaluateModelInputTensorsFormer(ModelInputTensorsFormer):
     def to_model_input_form(self, input_tensors: ReaderInputTensors):
-        return input_tensors.target_string, input_tensors.path_source_token_indices, input_tensors.path_indices, \
-               input_tensors.path_target_token_indices, input_tensors.context_valid_mask, \
-               input_tensors.path_source_token_strings, input_tensors.path_strings, \
-               input_tensors.path_target_token_strings
+        return (input_tensors.target_string, input_tensors.path_source_token_indices, input_tensors.path_indices,
+                input_tensors.path_target_token_indices, input_tensors.context_valid_mask,
+                input_tensors.path_source_token_strings, input_tensors.path_strings,
+                input_tensors.path_target_token_strings)
 
     def from_model_input_form(self, input_row) -> ReaderInputTensors:
         return ReaderInputTensors(


### PR DESCRIPTION
The old structure allows some errors in the manual testing of models, since the interpreter returns fewer values than it should, generating several errors in the test.
python: 3.6.9
tensorflow: 2.1.0