### PR TITLE
fix model_dir creation

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -13,6 +13,6 @@ data=${data_dir}/${dataset_name}
 test_data=${data_dir}/${dataset_name}.val.c2v
 model_dir=models/${type}
 
-mkdir -p models/${model_dir}
+mkdir -p ${model_dir}
 set -e
 python3 -u code2vec.py --data ${data} --test ${test_data} --save ${model_dir}/saved_model


### PR DESCRIPTION
Currently `train.sh` creates `/models/models/java14m`, but it should be `/models/java14m`