### PR TITLE
fix TFModel.evaluate() not to create saver when it exists

### DIFF
--- a/tensorflow_model.py
+++ b/tensorflow_model.py
@@ -123,7 +123,8 @@ class Code2VecModel(Code2VecModelBase):
 
             self.eval_top_words_op, self.eval_top_values_op, self.eval_original_names_op, _, _, _, _, \
                 self.eval_code_vectors = self._build_tf_test_graph(input_tensors)
-            self.saver = tf.compat.v1.train.Saver()
+            if self.saver is None:
+                self.saver = tf.compat.v1.train.Saver()
 
         if self.config.MODEL_LOAD_PATH and not self.config.TRAIN_DATA_PATH_PREFIX:
             self._initialize_session_variables()


### PR DESCRIPTION
`evaluate()` should not create a new saver object if it already exists, especially when `train()` created one beforehand in https://github.com/tech-srl/code2vec/blob/faaef36a23ac1ad4d018f47a50d7f814047d6b74/tensorflow_model.py#L57