### PR TITLE
use parameter file_path instead of data_file_path

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -65,7 +65,7 @@ def process_file(file_path, data_file_role, dataset_name, word_to_count, path_to
                 outfile.write(target_name + ' ' + " ".join(contexts) + csv_padding + '\n')
                 total += 1
 
-    print('File: ' + data_file_path)
+    print('File: ' + file_path)
     print('Average total contexts: ' + str(float(sum_total) / total))
     print('Average final (after sampling) contexts: ' + str(float(sum_sampled) / total))
     print('Total examples: ' + str(total))


### PR DESCRIPTION
At [line 68](https://github.com/tech-srl/code2vec/blob/0bafb06ff954d339475f7a8e4241cc3411e9dd6f/preprocess.py#L68) , `print('File: ' + data_file_path)` should be `print('File: ' + file_path)`, as `data_file_path`  has been sent as `file_path` from [line 133](https://github.com/tech-srl/code2vec/blob/0bafb06ff954d339475f7a8e4241cc3411e9dd6f/preprocess.py#L133). However, this is also true that both share the same value, but `data_file_path` is confusing to read.